### PR TITLE
PF2 macro generator: differentiate between PC and NCP attacks

### DIFF
--- a/src/macro/PF2ByRoll20.ts
+++ b/src/macro/PF2ByRoll20.ts
@@ -15,14 +15,28 @@ interface RepeatingDataSet {
 }
 
 let dataSet: {[id: string]: RepeatingDataSet} = {
-	"Melee Attacks": {
+	"NPC Melee Attacks": {
+		group: "repeating_melee-strikes",
+		name: "weapon",
+		macro: idx => `selected|repeating_melee-strikes_$${idx}_ATTACK-DAMAGE-NPC`,
+		hasMultiAttacks: true,
+	},
+
+	"NPC Ranged Attacks": {
+		group: "repeating_ranged-strikes",
+		name: "weapon",
+		macro: idx => `selected|repeating_ranged-strikes_$${idx}_ATTACK-DAMAGE-NPC`,
+	    hasMultiAttacks: true,
+	},
+
+	"Player Melee Attacks": {
 		group: "repeating_melee-strikes",
 		name: "weapon",
 		macro: idx => `selected|repeating_melee-strikes_$${idx}_ATTACK-DAMAGE`,
 		hasMultiAttacks: true,
 	},
 		
-	"Ranged Attacks": {
+	"Player Ranged Attacks": {
 		group: "repeating_ranged-strikes",
 		name: "weapon",
 		macro: idx => `selected|repeating_ranged-strikes_$${idx}_ATTACK-DAMAGE`,


### PR DESCRIPTION
Seems I missed to properly test the generator with NPC sheets... NPCs start their life using the PC character sheet, and after pressing the NPC button, the first melee attack still works using the regular macro because the unarmed attack was already there back before the sheet was an NPC sheet.

Long story short: NPCs need different calls for melee and ranged strikes, so macro generator now differentiates between PCs and NPCs for these. Spells of all sorts work with the same macros.

Sorry for the additional PR now :-/