### PR TITLE
Change deprecated Chrome link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <a href="https://addons.mozilla.org/en-US/firefox/addon/roll20-enhancement-suite/" target="_blank">
     <img src="assets/readme/firefox.png" alt="| for Firefox |"/>
   </a>
-  <a href="https://chrome.google.com/webstore/detail/roll20-enhancement-suite/fadcomaehamhdhekodcpiglabcjkepff" target="_blank">
+  <a href="https://justas-d.github.io/roll20-enhancement-suite/chrome.html" target="_blank">
     <img src="assets/readme/chrome.png" alt="| for Chrome |"/>
   </a>
 </p>


### PR DESCRIPTION
The extension is no longer in the Chrome Web Store. 